### PR TITLE
Option to select a provided style

### DIFF
--- a/app/renderer.js
+++ b/app/renderer.js
@@ -145,13 +145,6 @@ module.exports = class Renderer {
         if(index > -1) {
             styleFile = files[index];
             options.style = true;
-            console.log("using yamp style '" + styleFile + "'");
-        }
-        else if(options.style === true) {
-            console.log("using default style (" + styleFile + ")");
-        }
-        else {
-            console.log("using custom style");
         }
 
         return {

--- a/app/renderer.js
+++ b/app/renderer.js
@@ -80,7 +80,7 @@ module.exports = class Renderer {
         //Modify templateData before rendering
     }
 
-    //args: contentloadFileEJS 
+    //args: contentloadFileEJS
     afterRender() {
         //Modify rendered data
     }
@@ -138,8 +138,24 @@ module.exports = class Renderer {
 
     //TODO: change this for the temporal options directly
     setTemplateOptions(options) {
+        var files = fs.readdirSync(__dirname + "/../styles");
+        var index = files.indexOf(options.style);
+        var styleFile = "github-markdown.css";
+
+        if(index > -1) {
+            styleFile = files[index];
+            options.style = true;
+            console.log("using yamp style '" + styleFile + "'");
+        }
+        else if(options.style === true) {
+            console.log("using default style (" + styleFile + ")");
+        }
+        else {
+            console.log("using custom style");
+        }
+
         return {
-            styleFile: "github-markdown.css",
+            styleFile: styleFile,
             highlight: options.highlight && options.requireHighlight,
             style: options.style,
             resourcesPath: options.resourcesPath,

--- a/bin/yamp_cli.js
+++ b/bin/yamp_cli.js
@@ -24,6 +24,7 @@ commander.version(version)
     .option("--html", "html output")
     .option("--remark", "remark (html slides) output")
     .option("-t, --title [value]", "sets the html title")
+    .option("--list-styles", "lists all styles provided by yamp")
     .option("--style <file>", "custom css style")
     .option("--no-style", "disables css styling")
     .option("--minify", "minifies html output")
@@ -35,6 +36,21 @@ commander.version(version)
 if (!inputFile) {
     console.error("Invalid Input", "usage: yamp [options] <file>");
     process.exit(1);
+}
+
+if(commander.listStyles) {
+    const fs = require("fs");
+    console.log("\n  listing available styles\n");
+
+    var files = fs.readdirSync(__dirname + "/../styles");
+
+    for(var i = 0; i < files.length; i++) {
+        console.log("      *", files[i]);
+    }
+
+    console.log("\n  just provide one of these above as a file in --style option");
+    console.log("  default: --style 'github-markdown.css'\n");
+    process.exit(0);
 }
 
 let rendererOptions = {

--- a/templates/default.ejs
+++ b/templates/default.ejs
@@ -6,7 +6,7 @@
         <%if(style===true){%>
             <style><%- include("../styles/"+styleFile) %></style>
         <%}else if(style){ %>
-            <% var stylePath=process.cwd()+"/"+style; 
+            <% var stylePath=process.cwd()+"/"+style;
             try{%>
             <style><%- include(stylePath) %></style>
             <%} catch(e){ console.log("Warning: Style "+stylePath+" not found") }; %>
@@ -29,7 +29,7 @@
                 }
                 body {
                     padding: 0 45px 45px;
-        <% if(styleFile==="github-markdown.css"){%>         
+        <% if(styleFile==="github-markdown.css"){%>
                     font-size: 13px;
         <%}%>
                 }
@@ -37,7 +37,7 @@
         <%}%>
 
         <% if(koala===true){ %>
-            <% 
+            <%
             var backHeight="100%";
             if(output==="pdf") backHeight="824px";
             %>


### PR DESCRIPTION
Hi! I got an approach to add the feature mentioned at the issue #72.

I added --list-styles option in commander configuration. It justs outputs all files inside the styles folder.

Finally, I used the --style option to see if it holds a file name equals to any file inside the styles folder. If it's true, it uses a yamp-provided style. If not, it continues to work like before. 
