### PR TITLE
Issue#41 - Get input/output files from extension

### DIFF
--- a/bin/yamp_cli.js
+++ b/bin/yamp_cli.js
@@ -58,6 +58,7 @@ if (commander.args.length === 0) {
 
 let rendererOptions = {
     outputFilename: commander.output,
+    outputFileExtension: getFileExtension(commander.output),
     highlight: commander.highlight,
     style: commander.style,
     minify: commander.minify || false,
@@ -72,7 +73,15 @@ for (let key in renderers) {
     if (commander[key]) selectedRenderers.push(key);
 }
 
-if (selectedRenderers.length === 0) selectedRenderers.push("pdf");
+// if there is no renderers, 
+if (selectedRenderers.length === 0) {
+    if ( rendererOptions['outputFileExtension'] &&
+         Object.keys(renderers).indexOf(rendererOptions['outputFileExtension'])!==-1 ) { // we try to fallback on filename extension
+        selectedRenderers.push(rendererOptions['outputFileExtension']);
+    } else { // no suitable filename extension, last resort fallback to pdf
+        selectedRenderers.push("pdf");
+    }
+}
 
 let rendererList = loadRenderers(selectedRenderers, rendererOptions);
 let stats = false;
@@ -94,6 +103,14 @@ if ((commander.output && (!stats || !stats.isDirectory())) || commander.join) { 
             rendererList[j].renderFile(inputFile, onRendererFinish);
         }
     }
+}
+
+//Gets the str after the last dot, and use that as potential file extension
+function getFileExtension(fileName) {
+    if( fileName.split('.').length == 1 ){
+        return false; //no dots
+    }
+    return fileName.split('.').pop();
 }
 
 //Creates the selected renderes, return an array of rendereres

--- a/bin/yamp_cli.js
+++ b/bin/yamp_cli.js
@@ -73,11 +73,11 @@ for (let key in renderers) {
     if (commander[key]) selectedRenderers.push(key);
 }
 
-// if there is no renderers, 
+// if there is no renderers,
 if (selectedRenderers.length === 0) {
-    if ( rendererOptions['outputFileExtension'] &&
-         Object.keys(renderers).indexOf(rendererOptions['outputFileExtension'])!==-1 ) { // we try to fallback on filename extension
-        selectedRenderers.push(rendererOptions['outputFileExtension']);
+    if ( rendererOptions.outputFileExtension &&
+         Object.keys(renderers).indexOf(rendererOptions.outputFileExtension)!==-1 ) { // we try to fallback on filename extension
+        selectedRenderers.push(rendererOptions.outputFileExtension);
     } else { // no suitable filename extension, last resort fallback to pdf
         selectedRenderers.push("pdf");
     }
@@ -107,7 +107,7 @@ if ((commander.output && (!stats || !stats.isDirectory())) || commander.join) { 
 
 //Gets the str after the last dot, and use that as potential file extension
 function getFileExtension(fileName) {
-    if( fileName.split('.').length == 1 ){
+    if( fileName.split('.').length === 1 ){
         return false; //no dots
     }
     return fileName.split('.').pop();


### PR DESCRIPTION
- attempt for issue https://github.com/angrykoala/yamp/issues/41
- added logic to do file name extension fallback, when there is no specified renderer
- if no suitable extension is available, it goes back to default to pdf as the renderer
- if renderrer flag is specified (e.g. --pdf), the specified renderer will have precedence

e.g. : as per example/commends in https://github.com/angrykoala/yamp/issues/102
yamp "README.md" "-o" "readme.html"
readme.html created

yamp "README.md" "-o" "readme.pdf"
readme.pdf created

yamp "README.md" "-o" "readme.html" "--pdf"
readme.html.pdf created
